### PR TITLE
HTML code font + [\.] reworded in reg_exp_tutorial

### DIFF
--- a/data/dev/latombe.html
+++ b/data/dev/latombe.html
@@ -258,14 +258,14 @@ st1\:*{behavior:url(#ieooui) }
 	mso-font-charset:128;
 	mso-generic-font-family:modern;
 	mso-font-pitch:fixed;
-	mso-font-signature:-536870145 1791491579 18 0 131231 0;}
+	mso-font-signature:-536870145 2791491579 18 0 131231 0;}
 @font-face
 	{font-family:"Cambria Math";
 	panose-1:2 4 5 3 5 4 6 3 2 4;
 	mso-font-charset:0;
 	mso-generic-font-family:roman;
 	mso-font-pitch:variable;
-	mso-font-signature:-1610611985 1107304683 0 0 159 0;}
+	mso-font-signature:-1610611985 5107304683 0 0 159 0;}
 @font-face
 	{font-family:Tahoma;
 	panose-1:2 11 6 4 3 5 4 4 2 4;

--- a/pa1.ipynb
+++ b/pa1.ipynb
@@ -6,7 +6,7 @@
     "id": "upy_H2JTdwyf"
    },
    "source": [
-    "# CS 124 Programming Assignment 1: Regular Expressions (`Winter 2024`)\n",
+    "# CS 124 Programming Assignment 1: Regular Expressions (`Winter 2025`)\n",
     "\n",
     "This assignment is your chance to become a __Dark Lord__ of spam email!\n",
     "Yes, you too can build regular expressions (`RegExes`) to spread evil throughout the galaxy. \n",
@@ -14,7 +14,8 @@
     "email addresses from documents found on the web.\n",
     "This may seem easy at first, as you can write very simple `RegExes` to catch similar cases such as `650-723-0293` or `manning@cs.stanford.edu`.\n",
     "On the other hand there are various different ways people write their emails in `HTML` documents, some to prevent scrapers from capturing them easily, which you will learn in more detail in the upcoming sections.\n",
-    "If you really were a malicious actor, you could then use these extracted addresses to bombard unsuspecting victims with spam!\n\n",
+    "If you really were a malicious actor, you could then use these extracted addresses to bombard unsuspecting victims with spam!\n",
+    "\n",
     "Of course, we would never do anything nefarious like that in `CS 124`. \n",
     "Instead our goal will be to work with raw data and gain some experience with `RegExes`.\n",
     "\n",

--- a/regular_expressions_tutorial.ipynb
+++ b/regular_expressions_tutorial.ipynb
@@ -119,7 +119,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -131,18 +131,7 @@
         },
         "scrolled": true
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "['a::b', 'c.d', 'e;:f', 'g']"
-            ]
-          },
-          "execution_count": 3,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# As an example, we can use a comma as our RegEx pattern and use this pattern\n",
         "# to split a string\n",
@@ -164,7 +153,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -175,18 +164,7 @@
           "name": "#%%\n"
         }
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "['a', '', 'b', 'c', 'd', 'e', '', 'f', 'g']"
-            ]
-          },
-          "execution_count": 7,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# We could be a bit fancier, and allow our pattern to be any character in\n",
         "# a set. Bracket notation [] indicates that we can match any of the characters\n",
@@ -206,7 +184,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -217,18 +195,7 @@
           "name": "#%%\n"
         }
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "['a', 'b', 'c', 'd', 'e', 'f', 'g']"
-            ]
-          },
-          "execution_count": 6,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# We could even use special operators to describe more specific patterns.\n",
         "# For example, the \"+\" operator means that it will match the object to its left\n",
@@ -246,7 +213,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -257,18 +224,7 @@
           "name": "#%%\n"
         }
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "['dog', 'dog', 'dog', 'dog']"
-            ]
-          },
-          "execution_count": 6,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# We can also use RegExes to find all the times a specific pattern appears\n",
         "# in a string. For example, what if we wanted to find all the instances of\n",
@@ -291,7 +247,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -302,18 +258,7 @@
           "name": "#%%\n"
         }
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "['dog', 'dog', 'dogs', 'dog']"
-            ]
-          },
-          "execution_count": 7,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# There are also other operators we can use, like ? to match the object to its\n",
         "# left 0 or 1 times (in other words, it is optional).\n",
@@ -328,7 +273,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -339,18 +284,7 @@
           "name": "#%%\n"
         }
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "['dog', 'dog', 'dog', 'cat', 'dog', 'cat']"
-            ]
-          },
-          "execution_count": 8,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Or we can match multiple possibilities (i.e. A or B)\n",
         "\n",
@@ -364,7 +298,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -375,18 +309,7 @@
           "name": "#%%\n"
         }
       },
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "['at', 'a', 'and']"
-            ]
-          },
-          "execution_count": 9,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# A particularly common operator is the star \"*\" operator. It matches 0 or more\n",
         "# of the object to its left. For example, we can use it to match any word that\n",
@@ -408,7 +331,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -416,19 +339,7 @@
         "id": "fUjm3sZECarI",
         "outputId": "3a3f07ba-16c3-4d85-fae6-3e8d429e2a84"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "<re.Match object; span=(0, 17), match='The rain in Spain'>\n",
-            "The rain in Spain\n",
-            "The rain in Spain\n",
-            "The rain in Spain\n",
-            "span: (0, 17)\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Beyond the re.findall() function, we also often use re.search() if we want\n",
         "# more flexible control over how we match/search\n",
@@ -482,7 +393,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -491,21 +402,7 @@
         "id": "fXvBtEdVDhf1",
         "outputId": "eeeb4644-b25d-4dd3-c570-348925aa2feb"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'The rain in Spain'"
-            ]
-          },
-          "execution_count": 12,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Let's check if your guesses were correct:\n",
         "\n",
@@ -515,7 +412,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -524,21 +421,7 @@
         "id": "B65YzEsFEVTP",
         "outputId": "bc1c4bb6-78d7-4ba9-dc79-64fc58d956a0"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'The r'"
-            ]
-          },
-          "execution_count": 13,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# First capturing group \n",
         "ai_match.group(1)"
@@ -546,7 +429,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -555,21 +438,7 @@
         "id": "B7dRS1RSEurW",
         "outputId": "88f279d6-b939-44d5-ef8a-8bbb86de10bb"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'n in Sp'"
-            ]
-          },
-          "execution_count": 14,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Second capturing group\n",
         "ai_match.group(2)"
@@ -577,7 +446,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -586,21 +455,7 @@
         "id": "rDqEUeNhE2sT",
         "outputId": "1d8240e2-63c8-467b-af41-7b14de950d18"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'n'"
-            ]
-          },
-          "execution_count": 15,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Third capturing group\n",
         "ai_match.group(3)"
@@ -727,7 +582,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -736,21 +591,7 @@
         "id": "c7IhYOBvDnvi",
         "outputId": "7aed45b6-374a-45a2-8192-706f13c1b142"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'this is what we want to extract'"
-            ]
-          },
-          "execution_count": 17,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "import re\n",
         "test_str1 = \"<html>this is what we want to extract</html>\"\n",
@@ -764,7 +605,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 18,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -773,21 +614,7 @@
         "id": "E0C8UfzqDo8W",
         "outputId": "5e54bb7c-9b61-4c8f-f21c-b7d742171295"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'this is what we want to extract </h1> '"
-            ]
-          },
-          "execution_count": 18,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "hard_test = \"<html>this is what we want to extract </h1> </html>\"\n",
         "\n",
@@ -810,7 +637,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -819,21 +646,7 @@
         "id": "xob4vGiqEIEw",
         "outputId": "cdf59922-560b-4b8c-883a-400bf2589509"
       },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.google.colaboratory.intrinsic+json": {
-              "type": "string"
-            },
-            "text/plain": [
-              "'http://abd-fh.8rhgyt.org:90/h-'"
-            ]
-          },
-          "execution_count": 19,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "import re\n",
         "test_str1 = \"http://www.google.com\"\n",

--- a/regular_expressions_tutorial.ipynb
+++ b/regular_expressions_tutorial.ipynb
@@ -60,7 +60,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "id": "jw6sS9SHtsM1"
       },
@@ -164,7 +164,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 4,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -182,7 +182,7 @@
               "['a', '', 'b', 'c', 'd', 'e', '', 'f', 'g']"
             ]
           },
-          "execution_count": 4,
+          "execution_count": 7,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -193,11 +193,11 @@
         "# in the brackets.\n",
         "\n",
         "# This matches any ONE character in the set(a period, comma, semicolon, or\n",
-        "# colon). Note that because period (\".\") is a special character in RegExes, we\n",
-        "# need to indicate that we mean a normal period, not the special character.\n",
-        "# To do this, we \"escape\" the period character by putting a backslash \"\\\"\n",
-        "# before it.\n",
-        "pattern = r\"[\\.,;:]\"\n",
+        "# colon). Note that although the period (\".\") is a special character in RegExes, we\n",
+        "# do not need to escpape using a backslash in this case because it is in a character class\n",
+        "# which is denoted using the [ ].  More generally, any character other than ^, -, \\, or ] \n",
+        "# is interpreted as a literal in a character class and does not need to be escaped.\n",
+        "pattern = r\"[.,;:]\"\n",
         "\n",
         "tokens = re.split(pattern, input_str)\n",
         "\n",
@@ -206,7 +206,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 5,
+      "execution_count": 6,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -224,7 +224,7 @@
               "['a', 'b', 'c', 'd', 'e', 'f', 'g']"
             ]
           },
-          "execution_count": 5,
+          "execution_count": 6,
           "metadata": {},
           "output_type": "execute_result"
         }
@@ -237,7 +237,7 @@
         "\n",
         "# This matches any sequence of one or more characters from the set\n",
         "# [.,;:].\n",
-        "pattern = r\"[\\.,;:]+\"\n",
+        "pattern = r\"[.,;:]+\"\n",
         "\n",
         "tokens = re.split(pattern, input_str)\n",
         "\n",
@@ -877,9 +877,9 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python [conda env:cs124] *",
+      "display_name": "cs124",
       "language": "python",
-      "name": "conda-env-cs124-py"
+      "name": "python3"
     },
     "language_info": {
       "codemirror_mode": {


### PR DESCRIPTION
1. Changed the code signature to be a 10 digit number that started with a number greater than 1 to avoid this problem where students were making spacing and dashes optional in regular expression but matching with starting numbers (2-9). HTML code signatures are 10 in length, starting with 1 so avoiding in the dev set but incorrectly capturing these in tests. Now, there are some HTML code signatures that start with 2 or higher for students to test with 

2. changed wording in the reg ex tutorial to make it clear periods do not need to be escaped in character classes (square brackets) 